### PR TITLE
Fix 'FirstLast' template call for columns

### DIFF
--- a/code/ColumnedList.php
+++ b/code/ColumnedList.php
@@ -39,9 +39,17 @@ class ColumnedList extends SS_ListDecorator {
 		$result  = new ArrayList();
 
 		foreach($stacked as $list) {
+			$firstlast = '';
+			if($list == $stacked->First()) {
+				$firstlast = 'first';
+			} else if($list == $stacked->Last()) {
+				$firstlast = 'last';
+			}
+
 			$list = self::create($list);
 			$result->push(new ArrayData(array(
-				$children => $list
+				$children => $list,
+				'FirstLast' => $firstlast
 			)));
 		}
 


### PR DESCRIPTION
The FirstLast template function was returning 'First' for all columns when looping.
